### PR TITLE
feat: timecode countdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -758,6 +758,11 @@ class instance extends instance_skel {
 						if (response.code) {
 							this.formatToken = response.code;
 						}
+						break
+					case 'select':
+						// select will update internal cliplist so we should fetch those
+						this.updateClips()
+						break
 				}
 				this.checkFeedbacks()
 			}
@@ -1213,11 +1218,11 @@ class instance extends instance_skel {
 
 				for (let i = 0; i < slots; i++) {
 					this.slotInfo[i + 1] = await this.hyperDeck.sendCommand(new Commands.SlotInfoCommand(i + 1))
-					await this.updateClips(i + 1)
 				}
 
 				this.transportInfo = await this.hyperDeck.sendCommand(new Commands.TransportInfoCommand())
 
+				await this.updateClips(this.transportInfo.slotId)
 				this.status(this.STATUS_OK,'Connected')
 
 				this.initVariables()
@@ -1431,7 +1436,7 @@ class instance extends instance_skel {
 		const queryClips = await this.hyperDeck.sendCommand(clips)
 
 		this.clipsList[currentSlot] = queryClips.clips
-		console.log(queryClips.slotId, this.clipsList[queryClips.slotId])
+		// console.log(currentSlot, this.clipsList[currentSlot])
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -234,6 +234,12 @@ class instance extends instance_skel {
 			{ id: 'H.265High',             label: 'H.265 High',             family: 'H.265'        }
 		];
 
+		this.CONFIG_NOTIFICATION_METHOD = [
+			{ id: 'disabled', label: 'Disabled' },
+			{ id: 'notifications', label: 'Notifications' },
+			{ id: 'polling', label: 'Polling' },
+		]
+
 		this.CHOICES_MODEL = Object.values(this.CONFIG_MODEL);
 		// Sort alphabetical
 		this.CHOICES_MODEL.sort(function(a, b){
@@ -819,11 +825,7 @@ class instance extends instance_skel {
 				id:       'timecodeVariables',
 				label:    'Timecode Variables',
 				width:    6,
-				choices:  [
-					{ id: 'disabled', label: 'Disabled' },
-					{ id: 'notifications', label: 'Notifications' },
-					{ id: 'polling', label: 'Polling' },
-				],
+				choices:  this.CONFIG_NOTIFICATION_METHOD,
 				default:  'disabled'
 			},
 			{
@@ -1347,10 +1349,12 @@ class instance extends instance_skel {
 
 		if (this.protocolVersion >= 1.11 && this.config.timecodeVariables !== config.timecodeVariables && !resetConnection) {
 			if (this.config.timecodeVariables === 'notifications') {
+				// old config had notifications and new config does not
 				const notify = new Commands.NotifySetCommand()
 				notify.displayTimecode = false
 				this.hyperDeck.sendCommand(notify)
 			} else if (config.timecodeVariables === 'notifications') {
+				// old config had no notifications and new config does have them
 				const notify = new Commands.NotifySetCommand()
 				notify.displayTimecode = true
 				this.hyperDeck.sendCommand(notify)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"hyperdeck"
 	],
-	"version": "1.1.5",
+	"version": "1.2.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Recording",
@@ -27,6 +27,7 @@
 	],
 	"license": "MIT",
 	"dependencies": {
-		"hyperdeck-connection": "^0.4.4"
+		"hyperdeck-connection": "0.4.4-nightly-feat-v1-11-support-20210216-214339-7c9f73f.0",
+		"smpte-timecode": "^1.2.3"
 	}
 }

--- a/variables.js
+++ b/variables.js
@@ -1,0 +1,176 @@
+const Timecode = require('smpte-timecode')
+const { VideoFormat } = require('hyperdeck-connection')
+
+const frameRates = {
+    [VideoFormat.NTSC]: 29.97,
+	[VideoFormat.PAL]: 25,
+	[VideoFormat.NTSCp]: 29.97,
+	[VideoFormat.PALp]: 25,
+	[VideoFormat._720p50]: 50,
+	[VideoFormat._720p5994]: 59.94,
+	[VideoFormat._720p60]: 60,
+	[VideoFormat._1080p23976]: 23.897,
+	[VideoFormat._1080p24]: 24,
+	[VideoFormat._1080p25]: 25,
+	[VideoFormat._1080p2997]: 29.97,
+	[VideoFormat._1080p30]: 30,
+	[VideoFormat._1080i50]: 25,
+	[VideoFormat._1080i5994]: 29.97,
+	[VideoFormat._1080i60]: 30,
+	[VideoFormat._4Kp23976]: 23.976,
+	[VideoFormat._4Kp24]: 24,
+	[VideoFormat._4Kp25]: 25,
+	[VideoFormat._4Kp2997]: 29.97,
+	[VideoFormat._4Kp30]: 30,
+	[VideoFormat._4Kp50]: 50,
+	[VideoFormat._4Kp5994]: 59.94,
+	[VideoFormat._4Kp60]: 60,
+}
+
+module.exports.updateTransportInfoVariables = function(instance) {
+    instance.setVariable('status', instance.transportInfo['status']);
+    instance.setVariable('speed', instance.transportInfo['speed']);
+
+    //Clip ID and Slot ID  null exceptions
+    let clipIdVariable = '—';
+    if (instance.transportInfo['clipId'] != null) {
+        clipIdVariable = instance.transportInfo['clipId'];
+    }
+
+    let slotIdVariable = '—';
+    if (instance.transportInfo['slotId'] != null) {
+        slotIdVariable = instance.transportInfo['slotId'];
+    }
+    instance.setVariable('clipId', clipIdVariable);
+    instance.setVariable('slotId', slotIdVariable);
+    instance.setVariable('videoFormat', instance.transportInfo['videoFormat']);
+}
+
+module.exports.updateTimecodeVariables = function(instance) {
+    const tb = frameRates[instance.transportInfo['video format']] || 25
+    const countUp = {
+        tcH    : '',
+        tcM    : '',
+        tcS    : '',
+        tcF    : '',
+        tcHMS  : '',
+        tcHMSF : '',
+    }
+    let countDown = {
+        tcH    : '',
+        tcM    : '',
+        tcS    : '',
+        tcF    : '',
+        tcHMS  : '',
+        tcHMSF : '',
+    }
+
+    const pad = (n) => ('00' + n).substr(-2)
+
+    const setTcVariable = (isCountdown, { tcH, tcM, tcS, tcF, tcHMS, tcHMSF}) => {
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeHMS', tcHMS);
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeHMSF', tcHMSF);
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeH', pad(tcH));
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeM', pad(tcM));
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeS', pad(tcS));
+        instance.setVariable((isCountdown ? 'countdownT' : 't') + 'imecodeF', pad(tcF));
+    }
+
+    if (instance.transportInfo['displayTimecode']) {
+        let tc = Timecode(instance.transportInfo['displayTimecode'], tb)
+        countUp.tcH    = tc.hours;
+        countUp.tcM    = tc.minutes;
+        countUp.tcS    = tc.seconds;
+        countUp.tcF    = tc.frames;
+        countUp.tcHMS  = tc.toString().substr(0, 8);
+        countUp.tcHMSF = tc.toString();
+
+        if (instance.transportInfo['slotId'] !== undefined) {
+            const clip = instance.clipsList[instance.transportInfo['slotId']].find(({ clipId }) => clipId == instance.transportInfo['clipId'])
+            if (clip && clip.duration) {
+                const tcTot = Timecode(clip.duration, tb)
+                const tcStart = Timecode(clip.startTime, tb)
+                const left = tcTot.frameCount - (tc.frameCount - tcStart.frameCount) - 1
+                const tcLeft = Timecode(left, tb) // todo - unhardcode
+
+                countDown.tcH    = tcLeft.hours;
+                countDown.tcM    = tcLeft.minutes;
+                countDown.tcS    = tcLeft.seconds;
+                countDown.tcF    = tcLeft.frames;
+                countDown.tcHMS  = tcLeft.toString().substr(0, 8);
+                countDown.tcHMSF = tcLeft.toString();
+            }
+        }
+    }
+
+    setTcVariable(false, countUp),
+    setTcVariable(true, countDown)
+}
+
+module.exports.initVariables = function (instance) {
+    var variables = [];
+
+    // transport info vars:
+    variables.push({
+        label: 'Transport status',
+        name:  'status'
+    });
+    variables.push({
+        label: 'Play speed',
+        name:  'speed'
+    });
+    variables.push({
+        label: 'Clip ID',
+        name:  'clipId'
+    });
+    variables.push({
+        label: 'Slot ID',
+        name:  'slotId'
+    });
+    variables.push({
+        label: 'Video format',
+        name:  'videoFormat'
+    });
+    module.exports.updateTransportInfoVariables(instance)
+
+    // Timecode variables
+
+    const initTcVariable = (isCountdown) => {
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (HH:MM:SS)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeHMS'
+        });
+
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (HH:MM:SS:FF)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeHMSF'
+        });
+
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (HH)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeH'
+        });
+
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (MM)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeM'
+        });
+
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (SS)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeS'
+        });
+
+        variables.push({
+            label: (isCountdown ? 'Countdown ' : '') + 'Timecode (FF)',
+            name:  (isCountdown ? 'countdownT' : 't') + 'imecodeF'
+        });
+    }
+
+    initTcVariable(false)
+    initTcVariable(true)
+
+    module.exports.updateTimecodeVariables(instance)
+
+    instance.setVariableDefinitions(variables);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,24 @@
 # yarn lockfile v1
 
 
-hyperdeck-connection@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/hyperdeck-connection/-/hyperdeck-connection-0.4.4.tgz#ed569d1a6002311a27f9e8fbccc2c443acd61416"
-  integrity sha512-2+ezP4Gz5CvF/cdyAlU0coN4aRU/wesjUHjeJMN6Yex9jDrqvYmnOuB1soWY5LaetYShTO34MK2wPyYF50YOvg==
+hyperdeck-connection@0.4.4-nightly-feat-v1-11-support-20210216-214339-7c9f73f.0:
+  version "0.4.4-nightly-feat-v1-11-support-20210216-214339-7c9f73f.0"
+  resolved "https://registry.yarnpkg.com/hyperdeck-connection/-/hyperdeck-connection-0.4.4-nightly-feat-v1-11-support-20210216-214339-7c9f73f.0.tgz#131f548ffab192f0b2409704816846c5f0e78595"
+  integrity sha512-mERXyduv3kYYRhcz4onL55IgOn8eaSbnbNedaZq5c/2OR1tQAEcEGsb8OiEvhArO9Lxsy2GM8TvlyVdUQruyKQ==
   dependencies:
-    tslib "^1.9.0"
+    tslib "^2.0.3"
     underscore "^1.9.1"
     underscore-deep-extend "^1.1.5"
 
-tslib@^1.9.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+smpte-timecode@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/smpte-timecode/-/smpte-timecode-1.2.3.tgz#272ac8826724ce793d956109cfd3982b2f6b1893"
+  integrity sha512-6U+vdStmprzmpzEWS+9pw8GfiChBcMmJOdJxBjaXlGJhB9U/jcQhvh0buxJzEfhuX8E0OfYJy4hayBgAO92dBg==
+
+tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 underscore-deep-extend@^1.1.5:
   version "1.1.5"


### PR DESCRIPTION
This PR contains the following changes:
 * Query Hyperdeck for clips to be used in countdowns
 * Optionally use the new display timecode notifications from the hyperdeck instead of polling
 * Countdown timecode variables (Fixes https://github.com/bitfocus/companion-module-bmd-hyperdeck/issues/32)
 * Moved variables code into it's own file for clarity
 * Don't re-initiate all variables on timecode update, only update them

I think this is in a pretty good state I just need to figure what the right time is to rerun the query for clips but this is certainly ready for some testing and review. Once testing is done I'll coordinate a release of hyperdeck-connection as well.