### PR TITLE
Fix: Preview action doesn't work and throws an error

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -42,12 +42,8 @@ export function initActions(self: InstanceBaseExt) {
 		let value = options[key]
 		if (typeof value === 'boolean') return value
 		if (typeof value === 'string') {
-			if (value?.toLowerCase?.() === 'true') {
-				value = true
-			}else if (value?.toLowerCase?.() === 'false') {
-				value = false
-			}
-			if (typeof value === 'boolean') return value		
+			if (value.toLowerCase() === 'true')  return true
+			if (value.toLowerCase() === 'false') return false
 		}
 		throw new Error(`Invalid boolean for ${key}: ${options[key]} (${typeof value})`)
 	}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -41,8 +41,14 @@ export function initActions(self: InstanceBaseExt) {
 	const getOptBool = (options: CompanionOptionValues, key: string): boolean => {
 		let value = options[key]
 		if (typeof value === 'boolean') return value
-		value = Boolean(value)
-		if (typeof value === 'boolean') return value		
+		if (typeof value === 'string') {
+			if (value?.toLowerCase?.() === 'true') {
+				value = true
+			}else if (value?.toLowerCase?.() === 'false') {
+				value = false
+			}
+			if (typeof value === 'boolean') return value		
+		}
 		throw new Error(`Invalid boolean for ${key}: ${options[key]} (${typeof value})`)
 	}
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -32,16 +32,18 @@ export function initActions(self: InstanceBaseExt) {
 		if (typeof value === 'number') return value
 		value = Number(value)
 		if (!isNaN(value)) return value
-		throw new Error(`Invalid number for ${key}: ${options[key]}`)
+		throw new Error(`Invalid number for ${key}: ${options[key]} (${typeof value})`)
 	}
 	const getOptString = (options: CompanionOptionValues, key: string): string => {
 		const value = options[key]
 		return value?.toString() ?? ''
 	}
 	const getOptBool = (options: CompanionOptionValues, key: string): boolean => {
-		const value = options[key]
+		let value = options[key]
 		if (typeof value === 'boolean') return value
-		throw new Error(`Invalid boolean for ${key}: ${options[key]}`)
+		value = Boolean(value)
+		if (typeof value === 'boolean') return value		
+		throw new Error(`Invalid boolean for ${key}: ${options[key]} (${typeof value})`)
 	}
 
 	if (self.config.modelID != 'bmdDup4K') {


### PR DESCRIPTION
Edited the Preview action to convert true/false strings to boolean.
Closes issue #111 