### PR TITLE
feat: variable support in numerous actions and feedbacks

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -34,8 +34,18 @@ export function initActions(self: InstanceBaseExt) {
 		if (!isNaN(value)) return value
 		throw new Error(`Invalid number for ${key}: ${options[key]} (${typeof value})`)
 	}
+	const parseOptNumber = async (options: CompanionOptionValues, key: string): Promise<number> => {
+		const parsedValue = await self.parseVariablesInString(String(options[key]))
+		const value = Number(parsedValue)
+		if (!isNaN(value)) return value
+		throw new Error(`Invalid number for ${key}: ${parsedValue} (${typeof value})`)
+	}
 	const getOptString = (options: CompanionOptionValues, key: string): string => {
 		const value = options[key]
+		return value?.toString() ?? ''
+	}
+	const parseOptString = async (options: CompanionOptionValues, key: string): Promise<string> => {
+		const value = await self.parseVariablesInString(String(options[key]))
 		return value?.toString() ?? ''
 	}
 	const getOptBool = (options: CompanionOptionValues, key: string): boolean => {
@@ -60,7 +70,22 @@ export function initActions(self: InstanceBaseExt) {
 					min: 0 - maxShuttle,
 					max: maxShuttle,
 					range: true,
+					isVisible: (options) => options.useVariable === false || options.useVariable === undefined
 				},
+				{
+					type: 'textinput',
+					label: 'Speed %',
+					id: 'speedVar',
+					default: '',
+					useVariables: true,
+					isVisible: (options) => options.useVariable === true
+				},
+                {
+                    type: 'checkbox',
+                    label: 'Use variable for speed %',
+                    id: 'useVariable',
+                    default: false,
+                },
 				{
 					type: 'checkbox',
 					label: 'Loop clip',
@@ -75,11 +100,11 @@ export function initActions(self: InstanceBaseExt) {
 				},
 			],
 			callback: async ({ options }) => {
-				const cmd = new Commands.PlayCommand(
-					getOptString(options, 'speed'),
-					getOptBool(options, 'loop'),
-					getOptBool(options, 'single')
-				)
+				const cmd = new Commands.PlayCommand()
+				if (options.useVariable === false) cmd.speed = getOptString(options, 'speed')
+				else cmd.speed = await parseOptString(options, 'speedVar')
+				cmd.loop = getOptBool(options, 'loop')
+				cmd.singleClip = getOptBool(options, 'single')
 				await self.sendCommand(cmd)
 			},
 		}
@@ -221,11 +246,12 @@ export function initActions(self: InstanceBaseExt) {
 					id: 'tc',
 					default: '00:00:01:00',
 					regex: Regex.TIMECODE,
+					useVariables: true,
 				},
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				cmd.timecode = getOptString(options, 'tc')
+				cmd.timecode = await parseOptString(options, 'tc')
 				await self.sendCommand(cmd)
 			},
 		}
@@ -240,11 +266,28 @@ export function initActions(self: InstanceBaseExt) {
 					min: 1,
 					max: 999,
 					range: false,
+					isVisible: (options) => options.useVariable === false || options.useVariable === undefined
 				},
+				{
+					type: 'textinput',
+					label: 'Clip Number',
+					id: 'clipVar',
+					default: '',
+					useVariables: true,
+					isVisible: (options) => options.useVariable === true
+				},
+                {
+                    type: 'checkbox',
+                    label: 'Use Variable',
+                    id: 'useVariable',
+                    default: false,
+                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				cmd.clipId = getOptNumber(options, 'clip')
+				
+				if (options.useVariable === false) cmd.clipId = getOptNumber(options, 'clip')
+				else cmd.clipId = await parseOptNumber(options, 'clipVar')
 				await self.sendCommand(cmd)
 			},
 		}
@@ -288,11 +331,27 @@ export function initActions(self: InstanceBaseExt) {
 					min: 1,
 					max: 999,
 					range: false,
+					isVisible: (options) => options.useVariable === false || options.useVariable === undefined
 				},
+				{
+					type: 'textinput',
+					label: 'Number of clips',
+					id: 'clipVar',
+					default: '',
+					useVariables: true,
+					isVisible: (options) => options.useVariable === true
+				},
+                {
+                    type: 'checkbox',
+                    label: 'Use Variable',
+                    id: 'useVariable',
+                    default: false,
+                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				cmd.clipId = `+${options.clip}`
+				if (options.useVariable === false) cmd.clipId = `+${options.clip}`
+				else cmd.clipId = `+${await parseOptNumber(options, 'clipVar')}`
 				await self.sendCommand(cmd)
 			},
 		}
@@ -307,11 +366,27 @@ export function initActions(self: InstanceBaseExt) {
 					min: 1,
 					max: 999,
 					range: false,
+					isVisible: (options) => options.useVariable === false || options.useVariable === undefined
 				},
+				{
+					type: 'textinput',
+					label: 'Number of clips',
+					id: 'clipVar',
+					default: '',
+					useVariables: true,
+					isVisible: (options) => options.useVariable === true
+				},
+                {
+                    type: 'checkbox',
+                    label: 'Use Variable',
+                    id: 'useVariable',
+                    default: false,
+                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				cmd.clipId = `-${options.clip}`
+				if (options.useVariable === false) cmd.clipId = `-${options.clip}`
+				else cmd.clipId = `-${await parseOptNumber(options, 'clipVar')}`
 				await self.sendCommand(cmd)
 			},
 		}
@@ -341,11 +416,12 @@ export function initActions(self: InstanceBaseExt) {
 					id: 'jogFwdTc',
 					default: '00:00:00:01',
 					regex: Regex.TIMECODE,
+					useVariables: true,
 				},
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.JogCommand()
-				cmd.timecode = `+${options.jogFwdTc}`
+				cmd.timecode = `+${await parseOptString(options, 'jogFwdTc')}`
 				await self.sendCommand(cmd)
 			},
 		}
@@ -358,11 +434,12 @@ export function initActions(self: InstanceBaseExt) {
 					id: 'jogRewTc',
 					default: '00:00:00:01',
 					regex: Regex.TIMECODE,
+					useVariables: true,
 				},
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.JogCommand()
-				cmd.timecode = `-${options.jogRewTc}`
+				cmd.timecode = `-${await parseOptString(options, 'jogRewTc')}`
 				await self.sendCommand(cmd)
 			},
 		}
@@ -377,10 +454,27 @@ export function initActions(self: InstanceBaseExt) {
 					min: 0 - maxShuttle,
 					max: maxShuttle,
 					range: true,
+					isVisible: (options) => options.useVariable === false || options.useVariable === undefined
 				},
+				{
+					type: 'textinput',
+					label: 'Speed %',
+					id: 'speedVar',
+					default: '',
+					useVariables: true,
+					isVisible: (options) => options.useVariable === true
+				},
+                {
+                    type: 'checkbox',
+                    label: 'Use Variable',
+                    id: 'useVariable',
+                    default: false,
+                },
 			],
 			callback: async ({ options }) => {
-				const cmd = new Commands.ShuttleCommand(getOptNumber(options, 'speed'))
+				const cmd = new Commands.ShuttleCommand()
+				if (options.useVariable === false) cmd.speed = getOptNumber(options, 'speed')
+				else cmd.speed = await parseOptNumber(options, 'speedVar')
 				await self.sendCommand(cmd)
 			},
 		}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -101,7 +101,7 @@ export function initActions(self: InstanceBaseExt) {
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.PlayCommand()
-				if (options.useVariable === false) cmd.speed = getOptString(options, 'speed')
+				if (!options.useVariable) cmd.speed = getOptString(options, 'speed')
 				else cmd.speed = await parseOptString(options, 'speedVar')
 				cmd.loop = getOptBool(options, 'loop')
 				cmd.singleClip = getOptBool(options, 'single')
@@ -276,17 +276,17 @@ export function initActions(self: InstanceBaseExt) {
 					useVariables: true,
 					isVisible: (options) => options.useVariable === true
 				},
-                {
-                    type: 'checkbox',
-                    label: 'Use Variable',
-                    id: 'useVariable',
-                    default: false,
-                },
+		                {
+		                    type: 'checkbox',
+		                    label: 'Use Variable',
+		                    id: 'useVariable',
+		                    default: false,
+		                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
 				
-				if (options.useVariable === false) cmd.clipId = getOptNumber(options, 'clip')
+				if (!options.useVariable) cmd.clipId = getOptNumber(options, 'clip')
 				else cmd.clipId = await parseOptNumber(options, 'clipVar')
 				await self.sendCommand(cmd)
 			},
@@ -341,16 +341,16 @@ export function initActions(self: InstanceBaseExt) {
 					useVariables: true,
 					isVisible: (options) => options.useVariable === true
 				},
-                {
-                    type: 'checkbox',
-                    label: 'Use Variable',
-                    id: 'useVariable',
-                    default: false,
-                },
+		                {
+		                    type: 'checkbox',
+		                    label: 'Use Variable',
+		                    id: 'useVariable',
+		                    default: false,
+		                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				if (options.useVariable === false) cmd.clipId = `+${options.clip}`
+				if (!options.useVariable) cmd.clipId = `+${options.clip}`
 				else cmd.clipId = `+${await parseOptNumber(options, 'clipVar')}`
 				await self.sendCommand(cmd)
 			},
@@ -376,16 +376,16 @@ export function initActions(self: InstanceBaseExt) {
 					useVariables: true,
 					isVisible: (options) => options.useVariable === true
 				},
-                {
-                    type: 'checkbox',
-                    label: 'Use Variable',
-                    id: 'useVariable',
-                    default: false,
-                },
+		                {
+		                    type: 'checkbox',
+		                    label: 'Use Variable',
+		                    id: 'useVariable',
+		                    default: false,
+		                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.GoToCommand()
-				if (options.useVariable === false) cmd.clipId = `-${options.clip}`
+				if (!options.useVariable) cmd.clipId = `-${options.clip}`
 				else cmd.clipId = `-${await parseOptNumber(options, 'clipVar')}`
 				await self.sendCommand(cmd)
 			},
@@ -464,16 +464,16 @@ export function initActions(self: InstanceBaseExt) {
 					useVariables: true,
 					isVisible: (options) => options.useVariable === true
 				},
-                {
-                    type: 'checkbox',
-                    label: 'Use Variable',
-                    id: 'useVariable',
-                    default: false,
-                },
+		                {
+		                    type: 'checkbox',
+		                    label: 'Use Variable',
+		                    id: 'useVariable',
+		                    default: false,
+		                },
 			],
 			callback: async ({ options }) => {
 				const cmd = new Commands.ShuttleCommand()
-				if (options.useVariable === false) cmd.speed = getOptNumber(options, 'speed')
+				if (!options.useVariable) cmd.speed = getOptNumber(options, 'speed')
 				else cmd.speed = await parseOptNumber(options, 'speedVar')
 				await self.sendCommand(cmd)
 			},

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -49,6 +49,7 @@ export function initFeedbacks(self: InstanceBaseExt): CompanionFeedbackDefinitio
 				id: 'clipID',
 				default: '1',
 				regex: Regex.SIGNED_NUMBER,
+				useVariables: true,
 			},
 			{
 				type: 'dropdown',
@@ -63,7 +64,8 @@ export function initFeedbacks(self: InstanceBaseExt): CompanionFeedbackDefinitio
 			color: combineRgb(255, 255, 255),
 			bgcolor: combineRgb(0, 0, 0),
 		},
-		callback: ({ options }) => {
+		callback: async ({ options }, context) => {
+			options.clipID = Number(await context.parseVariablesInString(String(options.clipID)))
 			return (
 				(options.slotID == 'either' && options.clipID == self.transportInfo.clipId) ||
 				(options.slotID == self.transportInfo.slotId && options.clipID == self.transportInfo.clipId)
@@ -115,13 +117,15 @@ export function initFeedbacks(self: InstanceBaseExt): CompanionFeedbackDefinitio
 				id: 'setting',
 				default: '1',
 				regex: Regex.SIGNED_NUMBER,
+				useVariables: true,
 			},
 		],
 		defaultStyle: {
 			color: combineRgb(255, 255, 255),
 			bgcolor: combineRgb(0, 0, 0),
 		},
-		callback: ({ options }) => {
+		callback: async ({ options }, context) => {
+			options.setting = Number(await context.parseVariablesInString(String(options.setting)))
 			return options.setting == self.transportInfo.slotId
 		},
 	}
@@ -143,13 +147,15 @@ export function initFeedbacks(self: InstanceBaseExt): CompanionFeedbackDefinitio
 				id: 'slotId',
 				default: '1',
 				regex: Regex.SIGNED_NUMBER,
+				useVariables: true,
 			},
 		],
 		defaultStyle: {
 			color: combineRgb(255, 255, 255),
 			bgcolor: combineRgb(0, 0, 0),
 		},
-		callback: ({ options }) => {
+		callback: async ({ options }, context) => {
+			options.slotId = Number(await context.parseVariablesInString(String(options.slotId)))
 			const slot = self.slotInfo[Number(options.slotId)]
 			return !!slot && slot.status === options.status
 		},


### PR DESCRIPTION
Added variable support via toggle on following actions:
- Go forward (n) clips
- Go backward (n) clips
- Shuttle with speed (resolving #96)
- Play (resolving #48)

Added direct variable support on following actions:
- GOTO (TC) (resolving #82)
- Jog backward (TC) duration
- Jog forward (TC) duration

Added variable support on following feedbacks:
- Active clip
- Active slot
- Slot/disk status

Added "parseOptNumber" function to "actions.ts" to parse a number from textinput with variables from options object. Added "parseOptString" function to "actions.ts" to parse a string from textinput with variables from options object.