### PR TITLE
add play/stop toggle button

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -244,6 +244,35 @@ export function initActions(self: InstanceBaseExt) {
 			await self.sendCommand(cmd)
 		},
 	}
+	actions['playStopToggle'] = {
+		name: 'Play/Stop Toggle',
+		description: 'Toggle between Play and Stop based on current transport status',
+		options: [],
+		callback: async () => {
+			try {
+				if (self.transportInfo.status === 'play') {
+					// Currently playing, so stop
+					const cmd = new Commands.StopCommand()
+					await self.sendCommand(cmd)
+					self.log('info', 'Playback stopped via toggle')
+				} else {
+					// Not playing, so start playing
+					const cmd = new Commands.PlayCommand()
+					cmd.speed = '100'
+					cmd.loop = false
+					cmd.singleClip = false
+					await self.sendCommand(cmd)
+					self.log('info', 'Playback started via toggle')
+				}
+			} catch (error: any) {
+				if (error.message && error.message.includes('108')) {
+					self.log('warn', 'Internal error: HyperDeck may be busy or in an invalid state. Try again in a moment.')
+				} else {
+					self.log('error', `Play/Stop toggle failed: ${error.message || error}`)
+				}
+			}
+		},
+	}
 
 	if (self.config.modelID != 'bmdDup4K') {
 		actions['goto'] = {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -162,7 +162,41 @@ export function initPresets(self: InstanceBaseExt): CompanionPresetDefinitions {
 			},
 		],
 	}
-
+	presets.playStopToggle = {
+		type: 'button',
+		category: 'Transport',
+		name: 'Play/Stop Toggle',
+		style: {
+			text: '▶/■\nPlay/Stop',
+			size: '14',
+			color: colors.white,
+			bgcolor: colors.black,
+		},
+		feedbacks: [
+			{
+				feedbackId: 'transport_status',
+				options: { status: 'play' },
+				style: {
+					color: colors.white,
+					bgcolor: colors.green,
+				},
+			},
+			{
+				feedbackId: 'transport_status',
+				options: { status: 'stopped' },
+				style: {
+					color: colors.white,
+					bgcolor: colors.grey,
+				},
+			},
+		],
+		steps: [
+			{
+				down: [{ actionId: 'playStopToggle', options: {} }],
+				up: [],
+			},
+		],
+	}
     presets.goto = {
         type: 'button',
         category: 'Transport',


### PR DESCRIPTION
Adds a single button that toggles between play and stop states with visual feedback.
**Changes**:
New playStopToggle action and preset
Green background when playing, grey when stopped
Proper error handling
**Files**: src/actions.ts, src/presets.ts

**Benefits**:

Saves space on the Companion interface.
Improves ease-of-use by combining two related actions into a single intuitive control.